### PR TITLE
feat: add the uninstall command for this plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,22 @@ curl -fsSL https://raw.githubusercontent.com/sgyyz/kubectl-pg-tunnel/main/instal
 
 The installer will backup your existing installation and preserve your configuration.
 
+### Uninstall
+
+To uninstall kubectl-pg-tunnel:
+
+```bash
+kubectl pg-tunnel uninstall
+```
+
+Or run the uninstall script directly:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sgyyz/kubectl-pg-tunnel/main/uninstall.sh | bash
+```
+
+The uninstaller will prompt you whether to remove your configuration files.
+
 ### Configure
 
 ```bash

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -281,7 +281,25 @@ Press Ctrl+C in the first terminal to stop the tunnel.
 
 ## Uninstallation
 
-### Quick Uninstall
+### Method 1: Using the uninstall command (Recommended)
+
+```bash
+kubectl pg-tunnel uninstall
+```
+
+This command will:
+- Download and run the uninstaller
+- Prompt you to remove the plugin binary
+- Ask if you want to remove configuration files
+- Optionally clean up any running jump pods
+
+### Method 2: Direct uninstall script
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sgyyz/kubectl-pg-tunnel/main/uninstall.sh | bash
+```
+
+### Method 3: From cloned repository
 
 ```bash
 # If installed from the repository
@@ -289,7 +307,7 @@ cd kubectl-pg-tunnel
 ./uninstall.sh
 ```
 
-### Manual Uninstall
+### Method 4: Manual Uninstall
 
 ```bash
 # Remove the plugin

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -173,6 +173,22 @@ kubectl pg-tunnel --help
 kubectl pg-tunnel --version
 ```
 
+### Upgrade
+
+```bash
+kubectl pg-tunnel upgrade
+```
+
+Upgrades to the latest version from GitHub. Your configuration will be preserved.
+
+### Uninstall
+
+```bash
+kubectl pg-tunnel uninstall
+```
+
+Uninstalls kubectl-pg-tunnel. You'll be prompted whether to remove configuration files.
+
 ## Examples
 
 ### Connect with psql

--- a/kubectl-pg_tunnel
+++ b/kubectl-pg_tunnel
@@ -81,6 +81,7 @@ SUBCOMMANDS:
                            Optionally filter by environment
     edit-config            Open configuration file in \$EDITOR
     upgrade                Upgrade to the latest version
+    uninstall              Uninstall kubectl-pg-tunnel
     help                   Show this help message
     version                Show version information
 
@@ -327,6 +328,40 @@ upgrade_plugin() {
     fi
 }
 
+# Uninstall function
+uninstall_plugin() {
+    print_info "Uninstalling kubectl-pg-tunnel..."
+    echo ""
+
+    # Check if we have curl or wget
+    if command -v curl >/dev/null 2>&1; then
+        print_info "Downloading and running uninstaller..."
+        if curl -fsSL https://raw.githubusercontent.com/sgyyz/kubectl-pg-tunnel/main/uninstall.sh | bash; then
+            echo ""
+            print_success "Uninstall completed!"
+        else
+            print_error "Uninstall failed"
+            exit 1
+        fi
+    elif command -v wget >/dev/null 2>&1; then
+        print_info "Downloading and running uninstaller..."
+        if wget -qO- https://raw.githubusercontent.com/sgyyz/kubectl-pg-tunnel/main/uninstall.sh | bash; then
+            echo ""
+            print_success "Uninstall completed!"
+        else
+            print_error "Uninstall failed"
+            exit 1
+        fi
+    else
+        print_error "Neither curl nor wget found"
+        echo ""
+        echo "Please install curl or wget and try again:"
+        echo "  macOS:  brew install curl"
+        echo "  Linux:  sudo apt-get install curl"
+        exit 1
+    fi
+}
+
 # Cleanup function
 cleanup() {
     local pod_name="$1"
@@ -500,6 +535,10 @@ main() {
                 ;;
             upgrade)
                 upgrade_plugin
+                exit 0
+                ;;
+            uninstall)
+                uninstall_plugin
                 exit 0
                 ;;
             --env)

--- a/tests/pg_tunnel_test.bats
+++ b/tests/pg_tunnel_test.bats
@@ -301,6 +301,13 @@ EOSCRIPT
     [[ "$output" =~ "Upgrade to the latest version" ]]
 }
 
+@test "uninstall subcommand shows in help" {
+    run_plugin --help
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "uninstall" ]]
+    [[ "$output" =~ "Uninstall kubectl-pg-tunnel" ]]
+}
+
 # ==============================================================================
 # Validation Tests
 # ==============================================================================


### PR DESCRIPTION
This pull request adds an official uninstall command to the `kubectl-pg-tunnel` plugin, improving the user experience for removing the tool. The changes include implementation of the `uninstall` subcommand, documentation updates, and corresponding tests.

**Plugin enhancements:**
- Added a new `uninstall` subcommand to the plugin, which downloads and runs the official uninstaller script, with user prompts to optionally remove configuration files. This command works via both `curl` and `wget`, and provides clear error messages if neither is available. (`kubectl-pg_tunnel`) [[1]](diffhunk://#diff-5102070b5e2e6ae54b86f3b92632e7f3ac3baee3c1765942d0c5859c78a04283R84) [[2]](diffhunk://#diff-5102070b5e2e6ae54b86f3b92632e7f3ac3baee3c1765942d0c5859c78a04283R331-R364) [[3]](diffhunk://#diff-5102070b5e2e6ae54b86f3b92632e7f3ac3baee3c1765942d0c5859c78a04283R540-R543)

**Documentation updates:**
- Updated `README.md` to document the new uninstall command and script-based uninstall method, including user prompts for configuration cleanup.
- Expanded `docs/INSTALLATION.md` with a new "Uninstallation" section detailing four uninstall methods: recommended subcommand, direct script, from repository, and manual removal.
- Updated `docs/USAGE.md` to describe the new `uninstall` subcommand and usage details.

**Testing improvements:**
- Added a test to ensure the `uninstall` subcommand appears in the help output and is described correctly. (`tests/pg_tunnel_test.bats`)