### PR TITLE
feat: improve the pod name by connection type with random string

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Pre-commit hook for kubectl-pg-tunnel
+# Pre-commit hook for kubectl-tcp-tunnel
 # Runs shellcheck on all modified shell scripts
 
 set -e
@@ -22,7 +22,7 @@ if ! command -v shellcheck &>/dev/null; then
 fi
 
 # Get list of staged shell scripts
-FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(sh|bash)$|^kubectl-pg_tunnel$' || true)
+FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(sh|bash)$|^kubectl-tcp_tunnel$' || true)
 
 if [ -z "$FILES" ]; then
     echo -e "${GREEN}✓ No shell scripts to check${NC}"

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,4 +1,4 @@
-# shellcheck configuration for kubectl-pg-tunnel
+# shellcheck configuration for kubectl-tcp-tunnel
 
 # Disable specific rules if needed
 # SC1090: Can't follow non-constant source

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ Feature requests are welcome! Please open an issue with:
    shellcheck kubectl-tcp_tunnel install.sh uninstall.sh
 
    # Run tests
-   bats tests/pg_tunnel_test.bats
+   bats tests/tcp_tunnel_test.bats
 
    # Test installation
    ./install.sh
@@ -264,10 +264,10 @@ sudo apt-get install bats
 sudo dnf install bats
 
 # Run all tests
-bats tests/pg_tunnel_test.bats
+bats tests/tcp_tunnel_test.bats
 
 # Run specific test
-bats tests/pg_tunnel_test.bats -f "test name"
+bats tests/tcp_tunnel_test.bats -f "test name"
 ```
 
 ### Running Shellcheck

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 kubectl-pg-tunnel contributors
+Copyright (c) 2024 kubectl-tcp-tunnel contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -1,5 +1,5 @@
-# kubectl-pg-tunnel Configuration File
-# Copy this file to ~/.config/kubectl-pg-tunnel/config.yaml and customize
+# kubectl-tcp-tunnel Configuration File
+# Copy this file to ~/.config/kubectl-tcp-tunnel/config.yaml and customize
 
 # ==============================================================================
 # GLOBAL SETTINGS
@@ -115,22 +115,22 @@ environments:
 # Once configured, use the plugin like this:
 #
 #   # Connect to staging user database (PostgreSQL)
-#   kubectl pg-tunnel --env staging --db user-db
+#   kubectl tcp-tunnel --env staging --db user-db
 #
 #   # Connect to production analytics database (PostgreSQL)
-#   kubectl pg-tunnel --env production --db analytics-db
+#   kubectl tcp-tunnel --env production --db analytics-db
 #
 #   # Connect to Redis cache
-#   kubectl pg-tunnel --env staging --db cache
+#   kubectl tcp-tunnel --env staging --db cache
 #
 #   # Connect with custom local port (overrides type definition)
-#   kubectl pg-tunnel --env staging --db order-db --local-port 3307
+#   kubectl tcp-tunnel --env staging --db order-db --local-port 3307
 #
 #   # List all environments and connections
-#   kubectl pg-tunnel ls
+#   kubectl tcp-tunnel ls
 #
 #   # List connections for staging environment
-#   kubectl pg-tunnel ls staging
+#   kubectl tcp-tunnel ls staging
 #
 # ==============================================================================
 # CUSTOMIZATION NOTES

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -201,7 +201,7 @@ fi
 
 ### BATS Tests
 
-Tests are located in `tests/pg_tunnel_test.bats`.
+Tests are located in `tests/tcp_tunnel_test.bats`.
 
 #### Running Tests
 
@@ -210,10 +210,10 @@ Tests are located in `tests/pg_tunnel_test.bats`.
 make test
 
 # Run with BATS directly
-bats tests/pg_tunnel_test.bats
+bats tests/tcp_tunnel_test.bats
 
 # Run specific test
-bats tests/pg_tunnel_test.bats -f "shows help"
+bats tests/tcp_tunnel_test.bats -f "shows help"
 ```
 
 #### Writing Tests

--- a/kubectl-tcp_tunnel
+++ b/kubectl-tcp_tunnel
@@ -261,7 +261,18 @@ get_connection_db_port() {
 # Generate random alphanumeric string (lowercase)
 generate_random_suffix() {
     local length="${1:-6}"
-    LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c "${length}" || echo "$(date +%s | sha256sum | head -c "${length}")"
+    local suffix
+    # Try to generate random suffix from /dev/urandom
+    suffix=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom 2>/dev/null | head -c "${length}" || true)
+
+    # Fallback to timestamp-based generation if urandom fails
+    if [[ -z "${suffix}" ]] || [[ ${#suffix} -ne ${length} ]]; then
+        local timestamp
+        timestamp=$(date +%s)
+        suffix=$(printf "%s" "${timestamp}" | sha256sum 2>/dev/null | head -c "${length}" || printf "%s" "${timestamp}" | head -c "${length}")
+    fi
+
+    echo "${suffix}"
 }
 
 # Get connection type name from config
@@ -346,7 +357,7 @@ edit_config() {
 
             # Create a basic config template
             cat > "${CONFIG_FILE}" <<'EOF'
-# kubectl-pg-tunnel configuration
+# kubectl-tcp-tunnel configuration
 
 settings:
   namespace: default
@@ -399,14 +410,14 @@ EOF
 
 # Upgrade function
 upgrade_plugin() {
-    print_info "Upgrading kubectl-pg-tunnel..."
+    print_info "Upgrading kubectl-tcp-tunnel..."
     echo ""
 
     # Check if we have curl or wget
     if command -v curl >/dev/null 2>&1; then
         print_info "Downloading and running installer..."
         # shellcheck disable=SC2312
-        if FORCE_INSTALL=1 bash -c "$(curl -fsSL https://raw.githubusercontent.com/sgyyz/kubectl-pg-tunnel/main/install.sh)"; then
+        if FORCE_INSTALL=1 bash -c "$(curl -fsSL https://raw.githubusercontent.com/sgyyz/kubectl-tcp-tunnel/main/install.sh)"; then
             echo ""
             print_success "Upgrade completed successfully!"
             echo ""
@@ -418,7 +429,7 @@ upgrade_plugin() {
     elif command -v wget >/dev/null 2>&1; then
         print_info "Downloading and running installer..."
         # shellcheck disable=SC2312
-        if FORCE_INSTALL=1 bash -c "$(wget -qO- https://raw.githubusercontent.com/sgyyz/kubectl-pg-tunnel/main/install.sh)"; then
+        if FORCE_INSTALL=1 bash -c "$(wget -qO- https://raw.githubusercontent.com/sgyyz/kubectl-tcp-tunnel/main/install.sh)"; then
             echo ""
             print_success "Upgrade completed successfully!"
             echo ""
@@ -439,13 +450,13 @@ upgrade_plugin() {
 
 # Uninstall function
 uninstall_plugin() {
-    print_info "Uninstalling kubectl-pg-tunnel..."
+    print_info "Uninstalling kubectl-tcp-tunnel..."
     echo ""
 
     # Check if we have curl or wget
     if command -v curl >/dev/null 2>&1; then
         print_info "Downloading and running uninstaller..."
-        if curl -fsSL https://raw.githubusercontent.com/sgyyz/kubectl-pg-tunnel/main/uninstall.sh | bash; then
+        if curl -fsSL https://raw.githubusercontent.com/sgyyz/kubectl-tcp-tunnel/main/uninstall.sh | bash; then
             echo ""
             print_success "Uninstall completed!"
         else
@@ -454,7 +465,7 @@ uninstall_plugin() {
         fi
     elif command -v wget >/dev/null 2>&1; then
         print_info "Downloading and running uninstaller..."
-        if wget -qO- https://raw.githubusercontent.com/sgyyz/kubectl-pg-tunnel/main/uninstall.sh | bash; then
+        if wget -qO- https://raw.githubusercontent.com/sgyyz/kubectl-tcp-tunnel/main/uninstall.sh | bash; then
             echo ""
             print_success "Uninstall completed!"
         else


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the `kubectl-tcp-tunnel` project, most notably generalizing the project from `kubectl-pg-tunnel` to `kubectl-tcp-tunnel`, enhancing pod name generation logic, and improving test coverage for new features. The changes ensure more flexible support for different connection types (e.g., PostgreSQL, MySQL), improve maintainability, and update documentation and configuration accordingly.

**Project renaming and documentation updates:**
* Renamed all references from `kubectl-pg-tunnel` to `kubectl-tcp-tunnel` throughout scripts, configuration files, documentation, and license. This includes updates to `.githooks/pre-commit`, `.shellcheckrc`, `LICENSE`, `config/config.yaml.example`, and all relevant documentation. [[1]](diffhunk://#diff-87320095d7c4f39eed5d8f3866b512eb910e4eec8e7926faaeef6a53ab786fcbL3-R3) [[2]](diffhunk://#diff-c71502ae2fb6ee770263dbf93031c6bb1549ef6b2970b862daf24d01a1ded277L1-R1) [[3]](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3) [[4]](diffhunk://#diff-1281e242367d3afe688f6203748d19ec52be958dcdc4d76f84a40af5715d60adL1-R2) [[5]](diffhunk://#diff-1281e242367d3afe688f6203748d19ec52be958dcdc4d76f84a40af5715d60adL118-R133) [[6]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L90-R90) [[7]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L267-R270) [[8]](diffhunk://#diff-d9657425e036fb0ad2912c2c24ea793648eb86de5b40aa0844276dd08ed01d87L204-R204) [[9]](diffhunk://#diff-d9657425e036fb0ad2912c2c24ea793648eb86de5b40aa0844276dd08ed01d87L213-R216) [[10]](diffhunk://#diff-f3eb83bb9539c0d262f4068a0833d711535012044a242b67c29d5473da636db8L333-R360) [[11]](diffhunk://#diff-f3eb83bb9539c0d262f4068a0833d711535012044a242b67c29d5473da636db8L386-R420) [[12]](diffhunk://#diff-f3eb83bb9539c0d262f4068a0833d711535012044a242b67c29d5473da636db8L405-R432) [[13]](diffhunk://#diff-f3eb83bb9539c0d262f4068a0833d711535012044a242b67c29d5473da636db8L426-R459) [[14]](diffhunk://#diff-f3eb83bb9539c0d262f4068a0833d711535012044a242b67c29d5473da636db8L441-R468)

**New features and core logic improvements:**
* Added `generate_random_suffix` and `get_connection_type` functions to `kubectl-tcp_tunnel`, enabling the generation of unique, type-prefixed pod names for tunnels and supporting multiple connection types (e.g., postgres, mysql). Pod names now use the connection type as a prefix with a random suffix for uniqueness. [[1]](diffhunk://#diff-f3eb83bb9539c0d262f4068a0833d711535012044a242b67c29d5473da636db8R261-R287) [[2]](diffhunk://#diff-f3eb83bb9539c0d262f4068a0833d711535012044a242b67c29d5473da636db8L527-R568)
* Updated the pod name generation logic in `create_tunnel()` to use the new functions, improving clarity and avoiding naming collisions.

**Testing enhancements:**
* Extended `tests/tcp_tunnel_test.bats` with tests for the new `generate_random_suffix` and `get_connection_type` functions, as well as for multiple connection types in the same environment, ensuring correct pod name generation and connection handling. [[1]](diffhunk://#diff-1858d464222de45f90533ec18f19322c7c7a01d21d0a327fc971ca4608bbd8c5R110-R121) [[2]](diffhunk://#diff-1858d464222de45f90533ec18f19322c7c7a01d21d0a327fc971ca4608bbd8c5R143-R151) [[3]](diffhunk://#diff-1858d464222de45f90533ec18f19322c7c7a01d21d0a327fc971ca4608bbd8c5L384-R405) [[4]](diffhunk://#diff-1858d464222de45f90533ec18f19322c7c7a01d21d0a327fc971ca4608bbd8c5R421-R550)

**Configuration and helper script updates:**
* Updated example configuration and helper scripts to reflect the new naming and to demonstrate usage with multiple connection types. [[1]](diffhunk://#diff-1281e242367d3afe688f6203748d19ec52be958dcdc4d76f84a40af5715d60adL1-R2) [[2]](diffhunk://#diff-1281e242367d3afe688f6203748d19ec52be958dcdc4d76f84a40af5715d60adL118-R133)

These changes modernize the plugin, make it more generic and robust, and lay the groundwork for supporting additional tunnel types in the future.