### PR TITLE
feat: add the short arg for --env/-e --connection/-c --local-port/-p

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 
 # Claude Code
 .claude/
+CLAUDE.md
 
 # OS files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -65,19 +65,21 @@ curl -fsSL https://raw.githubusercontent.com/sgyyz/kubectl-tcp-tunnel/main/insta
 
 ```bash
 # Create tunnel to staging PostgreSQL database
-kubectl tcp-tunnel --env staging --connection user-db
+kubectl tcp-tunnel -e staging -c user-db
 # Connect: psql -h localhost -p 15432 -U myuser mydatabase
 
 # Create tunnel to staging MySQL database
-kubectl tcp-tunnel --env staging --connection order-db
+kubectl tcp-tunnel -e staging -c order-db
 # Connect: mysql -h localhost -P 13306 -u myuser mydatabase
 
 # Create tunnel to Redis cache
-kubectl tcp-tunnel --env staging --connection cache
+kubectl tcp-tunnel -e staging -c cache
 # Connect: redis-cli -h localhost -p 16379
 
-# Override local port
+# Override local port (using long form)
 kubectl tcp-tunnel --env staging --connection user-db --local-port 5433
+# Or using short form
+kubectl tcp-tunnel -e staging -c user-db -p 5433
 ```
 
 ## Requirements

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -114,16 +114,19 @@ environments:
 #
 # Once configured, use the plugin like this:
 #
-#   # Connect to staging user database (PostgreSQL)
-#   kubectl tcp-tunnel --env staging --connection user-db
+#   # Connect to staging user database (PostgreSQL) - short form
+#   kubectl tcp-tunnel -e staging -c user-db
 #
-#   # Connect to production analytics database (PostgreSQL)
+#   # Connect to production analytics database (PostgreSQL) - long form
 #   kubectl tcp-tunnel --env production --connection analytics-db
 #
-#   # Connect to Redis cache
-#   kubectl tcp-tunnel --env staging --connection cache
+#   # Connect to Redis cache - short form
+#   kubectl tcp-tunnel -e staging -c cache
 #
-#   # Connect with custom local port (overrides type definition)
+#   # Connect with custom local port - short form
+#   kubectl tcp-tunnel -e staging -c order-db -p 3307
+#
+#   # Connect with custom local port - long form
 #   kubectl tcp-tunnel --env staging --connection order-db --local-port 3307
 #
 #   # List all environments and connections

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -16,17 +16,18 @@ Comprehensive guide for using kubectl-tcp-tunnel for any TCP service.
 ### Command Syntax
 
 ```bash
+kubectl tcp-tunnel -e <environment> -c <connection> [OPTIONS]
 kubectl tcp-tunnel --env <environment> --connection <connection> [OPTIONS]
 ```
 
 ### Required Flags
 
-- `--env <environment>` - Environment to use (staging, production, etc.)
-- `--connection <connection>` - Connection alias to use (supports any TCP service)
+- `-e, --env <environment>` - Environment to use (staging, production, etc.)
+- `-c, --connection <connection>` - Connection alias to use (supports any TCP service)
 
 ### Optional Flags
 
-- `--local-port <port>` - Local port to forward to (overrides connection type default)
+- `-p, --local-port <port>` - Local port to forward to (overrides connection type default)
 - `--help` - Show help message
 - `--version` - Show version information
 
@@ -162,14 +163,14 @@ environments:
 ### Create a Tunnel
 
 ```bash
-# Connect to staging user database
-kubectl tcp-tunnel --env staging --connection user-db
+# Connect to staging user database (short form)
+kubectl tcp-tunnel -e staging -c user-db
 
-# Connect to production order database
+# Connect to production order database (long form)
 kubectl tcp-tunnel --env production --connection order-db
 
-# Use custom local port
-kubectl tcp-tunnel --env staging --connection user-db --local-port 5433
+# Use custom local port (short form)
+kubectl tcp-tunnel -e staging -c user-db -p 5433
 ```
 
 When the tunnel is established, you'll see:
@@ -255,8 +256,8 @@ Uninstalls kubectl-tcp-tunnel. You'll be prompted whether to remove configuratio
 ### Connect to PostgreSQL
 
 ```bash
-# Terminal 1: Create tunnel
-kubectl tcp-tunnel --env staging --connection user-db
+# Terminal 1: Create tunnel (short form)
+kubectl tcp-tunnel -e staging -c user-db
 
 # Terminal 2: Connect with psql
 psql -h localhost -p 15432 -U myuser mydatabase
@@ -265,8 +266,8 @@ psql -h localhost -p 15432 -U myuser mydatabase
 ### Connect to MySQL
 
 ```bash
-# Terminal 1: Create tunnel
-kubectl tcp-tunnel --env staging --connection order-db
+# Terminal 1: Create tunnel (short form)
+kubectl tcp-tunnel -e staging -c order-db
 
 # Terminal 2: Connect with mysql
 mysql -h localhost -P 13306 -u myuser mydatabase
@@ -275,8 +276,8 @@ mysql -h localhost -P 13306 -u myuser mydatabase
 ### Connect to Redis
 
 ```bash
-# Terminal 1: Create tunnel
-kubectl tcp-tunnel --env staging --connection cache
+# Terminal 1: Create tunnel (short form)
+kubectl tcp-tunnel -e staging -c cache
 
 # Terminal 2: Connect with redis-cli
 redis-cli -h localhost -p 16379
@@ -285,8 +286,8 @@ redis-cli -h localhost -p 16379
 ### Connect to MongoDB
 
 ```bash
-# Terminal 1: Create tunnel
-kubectl tcp-tunnel --env staging --connection mongo-db
+# Terminal 1: Create tunnel (short form)
+kubectl tcp-tunnel -e staging -c mongo-db
 
 # Terminal 2: Connect with mongosh
 mongosh "mongodb://localhost:17017/mydatabase"

--- a/kubectl-tcp_tunnel
+++ b/kubectl-tcp_tunnel
@@ -63,6 +63,7 @@ show_help() {
 ${SCRIPT_NAME} - Create TCP tunnels through Kubernetes jump pods
 
 USAGE:
+    ${SCRIPT_NAME} -e <environment> -c <connection> [OPTIONS]
     ${SCRIPT_NAME} --env <environment> --connection <connection> [OPTIONS]
     ${SCRIPT_NAME} <SUBCOMMAND>
 
@@ -72,11 +73,11 @@ DESCRIPTION:
     It simplifies secure service access without exposing services directly.
 
 OPTIONS:
-    --env <environment>       Environment to use (e.g., staging, production)
-    --connection <connection> Connection alias to use (supports any TCP service)
-    --local-port <port>       Local port to forward to (overrides connection type default)
-    --help                    Show this help message
-    --version                 Show version information
+    -e, --env <environment>       Environment to use (e.g., staging, production)
+    -c, --connection <connection> Connection alias to use (supports any TCP service)
+    -p, --local-port <port>       Local port to forward to (overrides connection type default)
+    --help                        Show this help message
+    --version                     Show version information
 
 SUBCOMMANDS:
     ls [environment]       List available environments and connections
@@ -90,12 +91,14 @@ SUBCOMMANDS:
 EXAMPLES:
     # Create tunnel to staging PostgreSQL database
     ${SCRIPT_NAME} --env staging --connection user-db
+    ${SCRIPT_NAME} -e staging -c user-db
 
     # Create tunnel to production MySQL with custom local port
     ${SCRIPT_NAME} --env production --connection order-db --local-port 3307
+    ${SCRIPT_NAME} -e production -c order-db -p 3307
 
     # Create tunnel to Redis cache
-    ${SCRIPT_NAME} --env staging --connection cache
+    ${SCRIPT_NAME} -e staging -c cache
 
     # List all available environments and connections
     ${SCRIPT_NAME} ls
@@ -679,25 +682,25 @@ main() {
                 uninstall_plugin
                 exit 0
                 ;;
-            --env)
+            --env|-e)
                 if [[ $# -lt 2 ]]; then
-                    print_error "Option --env requires an environment argument"
+                    print_error "Option --env/-e requires an environment argument"
                     exit 1
                 fi
                 environment="$2"
                 shift 2
                 ;;
-            --connection)
+            --connection|-c)
                 if [[ $# -lt 2 ]]; then
-                    print_error "Option --connection requires a connection argument"
+                    print_error "Option --connection/-c requires a connection argument"
                     exit 1
                 fi
                 database="$2"
                 shift 2
                 ;;
-            --local-port)
+            --local-port|-p)
                 if [[ $# -lt 2 ]]; then
-                    print_error "Option --local-port requires a port argument"
+                    print_error "Option --local-port/-p requires a port argument"
                     exit 1
                 fi
                 local_port="$2"
@@ -720,18 +723,20 @@ main() {
 
     # Validate required arguments for tunnel creation
     if [[ -z "${environment}" ]]; then
-        print_error "Missing required option: --env <environment>"
+        print_error "Missing required option: -e/--env <environment>"
         echo ""
-        echo "Usage: ${SCRIPT_NAME} --env <environment> --connection <connection>"
+        echo "Usage: ${SCRIPT_NAME} -e <environment> -c <connection>"
+        echo "   or: ${SCRIPT_NAME} --env <environment> --connection <connection>"
         echo ""
         echo "Use '${SCRIPT_NAME} ls' to see available environments"
         exit 1
     fi
 
     if [[ -z "${database}" ]]; then
-        print_error "Missing required option: --connection <connection>"
+        print_error "Missing required option: -c/--connection <connection>"
         echo ""
-        echo "Usage: ${SCRIPT_NAME} --env <environment> --connection <connection>"
+        echo "Usage: ${SCRIPT_NAME} -e <environment> -c <connection>"
+        echo "   or: ${SCRIPT_NAME} --env <environment> --connection <connection>"
         echo ""
         echo "Use '${SCRIPT_NAME} ls ${environment}' to see available connections"
         exit 1

--- a/tests/tcp_tunnel_test.bats
+++ b/tests/tcp_tunnel_test.bats
@@ -285,6 +285,39 @@ run_plugin() {
     [[ "$output" =~ "requires a port argument" ]]
 }
 
+@test "errors on -e without argument" {
+    run_plugin -e
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "requires an environment argument" ]]
+}
+
+@test "errors on -c without argument" {
+    run_plugin -c
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "requires a" ]]
+}
+
+@test "errors on -p without argument" {
+    run_plugin -p
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "requires a port argument" ]]
+}
+
+@test "accepts short arguments -e and -c" {
+    run_plugin -e staging -c user-db --help
+    [ "$status" -eq 0 ]
+}
+
+@test "accepts mixed short and long arguments" {
+    run_plugin -e staging --connection user-db --help
+    [ "$status" -eq 0 ]
+}
+
+@test "accepts short argument -p for local-port" {
+    run_plugin -e staging -c user-db -p 5433 --help
+    [ "$status" -eq 0 ]
+}
+
 # ==============================================================================
 # Config Handling Tests
 # ==============================================================================
@@ -380,13 +413,13 @@ EOSCRIPT
 @test "errors when missing --env argument" {
     run_plugin --connection user-db
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "Missing required option: --env" ]]
+    [[ "$output" =~ "Missing required option: -e/--env" ]]
 }
 
 @test "errors when missing --connection argument" {
     run_plugin --env staging
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "Missing required option: --connection" ]]
+    [[ "$output" =~ "Missing required option: -c/--connection" ]]
 }
 
 @test "errors on invalid environment" {


### PR DESCRIPTION
This pull request adds support for short-form command-line flags (`-e`, `-c`, `-p`) to the `kubectl-tcp-tunnel` plugin, updates documentation and help output to include both short and long forms, and enhances tests to cover new flag variants and error handling. The changes improve usability and consistency across the CLI, documentation, and tests.

**CLI Enhancements:**
- Added support for short-form flags: `-e` for `--env`, `-c` for `--connection`, and `-p` for `--local-port` in the main script, including validation and error messages that reference both forms. [[1]](diffhunk://#diff-f3eb83bb9539c0d262f4068a0833d711535012044a242b67c29d5473da636db8L682-R703) [[2]](diffhunk://#diff-f3eb83bb9539c0d262f4068a0833d711535012044a242b67c29d5473da636db8L723-R739)

**Documentation Updates:**
- Updated `README.md`, `docs/USAGE.md`, and example config files to show usage with both short and long flag forms, making examples clearer and more concise. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L68-R82) [[2]](diffhunk://#diff-1281e242367d3afe688f6203748d19ec52be958dcdc4d76f84a40af5715d60adL117-R129) [[3]](diffhunk://#diff-52296615debf3994195e43d91c94e02bfdc615a27620e0dbc72140b3de98dde1R19-R30) [[4]](diffhunk://#diff-52296615debf3994195e43d91c94e02bfdc615a27620e0dbc72140b3de98dde1L165-R173) [[5]](diffhunk://#diff-52296615debf3994195e43d91c94e02bfdc615a27620e0dbc72140b3de98dde1L258-R260) [[6]](diffhunk://#diff-52296615debf3994195e43d91c94e02bfdc615a27620e0dbc72140b3de98dde1L268-R270) [[7]](diffhunk://#diff-52296615debf3994195e43d91c94e02bfdc615a27620e0dbc72140b3de98dde1L278-R280) [[8]](diffhunk://#diff-52296615debf3994195e43d91c94e02bfdc615a27620e0dbc72140b3de98dde1L288-R290)
- Improved help output in the CLI to document both short and long options. [[1]](diffhunk://#diff-f3eb83bb9539c0d262f4068a0833d711535012044a242b67c29d5473da636db8R66) [[2]](diffhunk://#diff-f3eb83bb9539c0d262f4068a0833d711535012044a242b67c29d5473da636db8L75-R78) [[3]](diffhunk://#diff-f3eb83bb9539c0d262f4068a0833d711535012044a242b67c29d5473da636db8R94-R101)

**Testing Improvements:**
- Added new tests to ensure short-form flags are accepted, mixed usage works, and appropriate error messages are shown when required arguments are missing. Updated existing tests to match new error message formats. [[1]](diffhunk://#diff-1858d464222de45f90533ec18f19322c7c7a01d21d0a327fc971ca4608bbd8c5R288-R320) [[2]](diffhunk://#diff-1858d464222de45f90533ec18f19322c7c7a01d21d0a327fc971ca4608bbd8c5L383-R422)