### PR TITLE
feat: remove the CHANGELOG.md.bak after completed the release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,9 @@ release:
 	@echo ""
 	@echo "✅ Release v$(VERSION) created!"
 	@echo ""
+	@echo "Cleaning up backup files..."
+	@rm -f CHANGELOG.md.bak
+	@echo ""
 	@echo "Next step: Push to GitHub"
 	@echo "  git push origin main --tags"
 	@echo ""


### PR DESCRIPTION
This pull request makes a minor update to the release process in the `Makefile` by adding a cleanup step to remove backup files after creating a release.

* Release process improvement:
  * Added commands to delete the `CHANGELOG.md.bak` backup file after a release, ensuring a cleaner workspace.