### PR TITLE
fix: set the default branch for the CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kubectl-tcp-tunnel
 
-[![CI](https://github.com/sgyyz/kubectl-tcp-tunnel/actions/workflows/ci.yml/badge.svg)](https://github.com/sgyyz/kubectl-tcp-tunnel/actions/workflows/ci.yml)
+[![CI](https://github.com/sgyyz/kubectl-tcp-tunnel/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/sgyyz/kubectl-tcp-tunnel/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A kubectl plugin that simplifies creating secure TCP tunnels through Kubernetes jump pods. Supports any TCP service including PostgreSQL, MySQL, Redis, MongoDB, and more.


### PR DESCRIPTION
This pull request makes a small update to the CI badge in the `README.md` file, ensuring it always displays the status for the `main` branch.

* Updated the CI badge URL to reference the `main` branch in `README.md`.