### PR TITLE
fix: db-port is not working and change the db-port to remote-port

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -19,19 +19,19 @@ settings:
   # Connection type definitions (use YAML anchors for reusability)
   postgres: &postgres
     local-port: 15432
-    db-port: 5432
+    remote-port: 5432
 
   mysql: &mysql
     local-port: 13306
-    db-port: 3306
+    remote-port: 3306
 
   redis: &redis
     local-port: 16379
-    db-port: 6379
+    remote-port: 6379
 
   mongodb: &mongodb
     local-port: 17017
-    db-port: 27017
+    remote-port: 27017
 
 # ==============================================================================
 # ENVIRONMENTS
@@ -100,7 +100,7 @@ environments:
 # settings:
 #   custom-service: &custom-service
 #     local-port: 18080
-#     db-port: 8080
+#     remote-port: 8080
 #
 # Then reference it in your connections:
 #   connections:

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -160,15 +160,15 @@ settings:
   # Define connection types with YAML anchors
   postgres: &postgres
     local-port: 15432
-    db-port: 5432
+    remote-port: 5432
 
   mysql: &mysql
     local-port: 13306
-    db-port: 3306
+    remote-port: 3306
 
   redis: &redis
     local-port: 16379
-    db-port: 6379
+    remote-port: 6379
 
 environments:
   # Update with your actual Kubernetes context name
@@ -227,19 +227,19 @@ settings:
   # Connection type definitions
   postgres: &postgres
     local-port: 15432
-    db-port: 5432
+    remote-port: 5432
 
   mysql: &mysql
     local-port: 13306
-    db-port: 3306
+    remote-port: 3306
 
   redis: &redis
     local-port: 16379
-    db-port: 6379
+    remote-port: 6379
 
   mongodb: &mongodb
     local-port: 17017
-    db-port: 27017
+    remote-port: 27017
 
 environments:
   dev:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -51,19 +51,19 @@ settings:
   # Define connection types with YAML anchors
   postgres: &postgres
     local-port: 15432
-    db-port: 5432
+    remote-port: 5432
 
   mysql: &mysql
     local-port: 13306
-    db-port: 3306
+    remote-port: 3306
 
   redis: &redis
     local-port: 16379
-    db-port: 6379
+    remote-port: 6379
 
   mongodb: &mongodb
     local-port: 17017
-    db-port: 27017
+    remote-port: 27017
 
 # Define environments
 environments:
@@ -99,7 +99,7 @@ environments:
 | `settings.jump-pod-image` | Docker image with socat | `alpine/socat:latest` |
 | `settings.jump-pod-wait-timeout` | Seconds to wait for pod ready | `60` |
 | `settings.<type>.local-port` | Local port for connection type | Type-specific |
-| `settings.<type>.db-port` | Remote port for connection type | Type-specific |
+| `settings.<type>.remote-port` | Remote port for connection type | Type-specific |
 | `environments.<name>.k8s-context` | Kubectl context for environment | Required |
 | `environments.<name>.connections.<alias>.host` | Service hostname | Required |
 | `environments.<name>.connections.<alias>.type` | Connection type (YAML anchor) | Required |
@@ -139,12 +139,12 @@ settings:
   # Custom application on port 8080
   myapp: &myapp
     local-port: 18080
-    db-port: 8080
+    remote-port: 8080
 
   # SSH tunnel
   ssh: &ssh
     local-port: 2222
-    db-port: 22
+    remote-port: 22
 
 environments:
   staging:
@@ -393,7 +393,7 @@ Version 2.0 introduces a **breaking change** to support generic TCP connections.
 ```yaml
 settings:
   local-port: 5432
-  db-port: 5432
+  remote-port: 5432
 
 environments:
   staging:
@@ -409,11 +409,11 @@ environments:
 settings:
   postgres: &postgres
     local-port: 15432
-    db-port: 5432
+    remote-port: 5432
 
   mysql: &mysql
     local-port: 13306
-    db-port: 3306
+    remote-port: 3306
 
 environments:
   staging:
@@ -439,7 +439,7 @@ environments:
    settings:
      postgres: &postgres
        local-port: 15432
-       db-port: 5432
+       remote-port: 5432
    ```
 
 3. **Rename `databases:` to `connections:`:**

--- a/kubectl-tcp_tunnel
+++ b/kubectl-tcp_tunnel
@@ -18,7 +18,7 @@ DEFAULT_NAMESPACE="default"
 DEFAULT_JUMP_POD_IMAGE="alpine/socat:latest"
 DEFAULT_JUMP_POD_WAIT_TIMEOUT="60"
 DEFAULT_LOCAL_PORT="5432"
-DEFAULT_DB_PORT="5432"
+DEFAULT_REMOTE_PORT="5432"
 
 # Color codes for output
 RED='\033[0;31m'
@@ -254,11 +254,11 @@ get_connection_local_port() {
     yq eval "explode(.) | .environments.${env}.connections.${conn}.type.local-port // \"\"" "${CONFIG_FILE}" 2>/dev/null
 }
 
-# Get connection db-port (from type definition)
-get_connection_db_port() {
+# Get connection remote-port (from type definition)
+get_connection_remote_port() {
     local env="$1"
     local conn="$2"
-    yq eval "explode(.) | .environments.${env}.connections.${conn}.type.db-port // \"\"" "${CONFIG_FILE}" 2>/dev/null
+    yq eval "explode(.) | .environments.${env}.connections.${conn}.type.remote-port // \"\"" "${CONFIG_FILE}" 2>/dev/null
 }
 
 # Generate random alphanumeric string (lowercase)
@@ -370,15 +370,15 @@ settings:
   # Connection type definitions with YAML anchors
   postgres: &postgres
     local-port: 15432
-    db-port: 5432
+    remote-port: 5432
 
   mysql: &mysql
     local-port: 13306
-    db-port: 3306
+    remote-port: 3306
 
   redis: &redis
     local-port: 16379
-    db-port: 6379
+    remote-port: 6379
 
 environments:
   staging:
@@ -512,18 +512,18 @@ create_tunnel() {
     local namespace
     local jump_pod_image
     local jump_pod_wait_timeout
-    local db_port
+    local remote_port
 
     namespace=$(get_setting "namespace" "${DEFAULT_NAMESPACE}")
     jump_pod_image=$(get_setting "jump-pod-image" "${DEFAULT_JUMP_POD_IMAGE}")
     jump_pod_wait_timeout=$(get_setting "jump-pod-wait-timeout" "${DEFAULT_JUMP_POD_WAIT_TIMEOUT}")
 
-    # Try to get db-port from connection type definition first
-    db_port=$(get_connection_db_port "${environment}" "${database}")
+    # Try to get remote-port from connection type definition first
+    remote_port=$(get_connection_remote_port "${environment}" "${database}")
 
     # If not found in connection type, fall back to global setting
-    if [[ -z "${db_port}" ]] || [[ "${db_port}" == "null" ]]; then
-        db_port=$(get_setting "db-port" "${DEFAULT_DB_PORT}")
+    if [[ -z "${remote_port}" ]] || [[ "${remote_port}" == "null" ]]; then
+        remote_port=$(get_setting "remote-port" "${DEFAULT_REMOTE_PORT}")
     fi
 
     # Get environment context
@@ -576,7 +576,7 @@ create_tunnel() {
     print_info "Namespace: ${namespace}"
     print_info "Jump pod: ${pod_name}"
     print_info "Local port: ${local_port}"
-    print_info "Remote port: ${db_port}"
+    print_info "Remote port: ${remote_port}"
     echo ""
 
     # Set up cleanup trap with current values
@@ -605,7 +605,7 @@ create_tunnel() {
     if ! kubectl --context="${context}" -n "${namespace}" run "${pod_name}" \
         --image="${jump_pod_image}" \
         --restart=Never \
-        --command -- socat TCP-LISTEN:5432,fork,reuseaddr TCP:"${db_host}":"${db_port}"; then
+        --command -- socat TCP-LISTEN:"${remote_port}",fork,reuseaddr TCP:"${db_host}":"${remote_port}"; then
         print_error "Failed to create jump pod"
         exit 1
     fi
@@ -627,7 +627,7 @@ create_tunnel() {
     echo ""
     print_success "Tunnel established!"
     print_info "Local:  localhost:${local_port}"
-    print_info "Remote: ${db_host}:${db_port}"
+    print_info "Remote: ${db_host}:${remote_port}"
     echo ""
     print_info "You can now connect to localhost:${local_port}"
     echo ""
@@ -635,7 +635,7 @@ create_tunnel() {
     echo ""
 
     # Port forward (this blocks until Ctrl+C)
-    kubectl --context="${context}" -n "${namespace}" port-forward pod/"${pod_name}" "${local_port}":5432
+    kubectl --context="${context}" -n "${namespace}" port-forward pod/"${pod_name}" "${local_port}":"${remote_port}"
 }
 
 # Main function

--- a/tests/tcp_tunnel_test.bats
+++ b/tests/tcp_tunnel_test.bats
@@ -23,11 +23,11 @@ settings:
 
   postgres: &postgres
     local-port: 15432
-    db-port: 5432
+    remote-port: 5432
 
   mysql: &mysql
     local-port: 13306
-    db-port: 3306
+    remote-port: 3306
 
 environments:
   staging:
@@ -71,7 +71,7 @@ case "$query" in
     ".settings.jump-pod-wait-timeout")
         echo "60"
         ;;
-    ".settings.db-port")
+    ".settings.remote-port")
         echo "5432"
         ;;
     ".settings.local-port")
@@ -98,13 +98,13 @@ case "$query" in
     "explode(.) | .environments.staging.connections.user-db.type.local-port")
         echo "15432"
         ;;
-    "explode(.) | .environments.staging.connections.user-db.type.db-port")
+    "explode(.) | .environments.staging.connections.user-db.type.remote-port")
         echo "5432"
         ;;
     "explode(.) | .environments.staging.connections.order-db.type.local-port")
         echo "13306"
         ;;
-    "explode(.) | .environments.staging.connections.order-db.type.db-port")
+    "explode(.) | .environments.staging.connections.order-db.type.remote-port")
         echo "3306"
         ;;
     ".environments.staging.connections.user-db.type")
@@ -122,7 +122,7 @@ case "$query" in
     "explode(.) | .environments.production.connections.user-db.type.local-port")
         echo "15432"
         ;;
-    "explode(.) | .environments.production.connections.user-db.type.db-port")
+    "explode(.) | .environments.production.connections.user-db.type.remote-port")
         echo "5432"
         ;;
     "explode(.) | .environments.staging.connections.unknown_db.host")
@@ -134,7 +134,7 @@ case "$query" in
     "explode(.) | .environments.staging.connections.unknown_db.type.local-port")
         echo ""
         ;;
-    "explode(.) | .environments.staging.connections.unknown_db.type.db-port")
+    "explode(.) | .environments.staging.connections.unknown_db.type.remote-port")
         echo ""
         ;;
     "explode(.) | .environments.staging.connections.nonexistent_db.host")
@@ -534,10 +534,10 @@ settings:
   namespace: default
   postgres: &postgres
     local-port: 15432
-    db-port: 5432
+    remote-port: 5432
   mysql: &mysql
     local-port: 13306
-    db-port: 3306
+    remote-port: 3306
 
 environments:
   staging:
@@ -563,9 +563,9 @@ case "$query" in
     "explode(.) | .environments.staging.connections.user-db.host") echo "postgres.example.com" ;;
     "explode(.) | .environments.staging.connections.order-db.host") echo "mysql.example.com" ;;
     "explode(.) | .environments.staging.connections.user-db.type.local-port") echo "15432" ;;
-    "explode(.) | .environments.staging.connections.user-db.type.db-port") echo "5432" ;;
+    "explode(.) | .environments.staging.connections.user-db.type.remote-port") echo "5432" ;;
     "explode(.) | .environments.staging.connections.order-db.type.local-port") echo "13306" ;;
-    "explode(.) | .environments.staging.connections.order-db.type.db-port") echo "3306" ;;
+    "explode(.) | .environments.staging.connections.order-db.type.remote-port") echo "3306" ;;
     ".environments | keys | .[]") echo "staging" ;;
     ".environments.staging.connections | keys | .[]")
         echo "order-db"
@@ -676,7 +676,7 @@ settings:
   namespace: default
   postgres: &postgres
     local-port: 15432
-    db-port: 5432
+    remote-port: 5432
 
 environments:
   staging:
@@ -696,7 +696,7 @@ case "$query" in
     ".environments.staging.k8s-context") echo "staging-context" ;;
     "explode(.) | .environments.staging.connections.user-db.host") echo "postgres-staging.example.com" ;;
     "explode(.) | .environments.staging.connections.user-db.type.local-port") echo "15432" ;;
-    "explode(.) | .environments.staging.connections.user-db.type.db-port") echo "5432" ;;
+    "explode(.) | .environments.staging.connections.user-db.type.remote-port") echo "5432" ;;
     *) echo "" ;;
 esac
 exit 0
@@ -715,7 +715,7 @@ settings:
   namespace: default
   postgres: &postgres
     local-port: 15432
-    db-port: 5432
+    remote-port: 5432
 
 environments:
   staging:
@@ -778,14 +778,14 @@ case "$query" in
     ".environments.staging.connections.raw-service.type") echo "" ;;
     "explode(.) | .environments.staging.connections.raw-service.host") echo "service.example.com" ;;
     "explode(.) | .environments.staging.connections.raw-service.type.local-port") echo "" ;;
-    "explode(.) | .environments.staging.connections.raw-service.type.db-port") echo "" ;;
+    "explode(.) | .environments.staging.connections.raw-service.type.remote-port") echo "" ;;
     ".environments | keys | .[]") echo "staging" ;;
     ".environments.staging.connections | keys | .[]") echo "raw-service" ;;
     ".settings.namespace") echo "default" ;;
     ".settings.jump-pod-image") echo "alpine/socat:latest" ;;
     ".settings.jump-pod-wait-timeout") echo "60" ;;
     ".settings.local-port") echo "5432" ;;
-    ".settings.db-port") echo "5432" ;;
+    ".settings.remote-port") echo "5432" ;;
     *) echo "" ;;
 esac
 exit 0
@@ -804,7 +804,7 @@ settings:
   namespace: default
   postgres: &postgres
     local-port: 15432
-    db-port: 5432
+    remote-port: 5432
 
 environments:
   staging:
@@ -859,7 +859,7 @@ settings:
   namespace: default
   redis: &redis
     local-port: 16379
-    db-port: 6379
+    remote-port: 6379
 
 environments:
   staging:
@@ -880,7 +880,7 @@ case "$query" in
     ".environments.staging.connections.cache.type") echo "*redis" ;;
     "explode(.) | .environments.staging.connections.cache.host") echo "redis.example.com" ;;
     "explode(.) | .environments.staging.connections.cache.type.local-port") echo "16379" ;;
-    "explode(.) | .environments.staging.connections.cache.type.db-port") echo "6379" ;;
+    "explode(.) | .environments.staging.connections.cache.type.remote-port") echo "6379" ;;
     ".environments | keys | .[]") echo "staging" ;;
     ".environments.staging.connections | keys | .[]") echo "cache" ;;
     *) echo "" ;;
@@ -900,7 +900,7 @@ settings:
   namespace: default
   mongodb: &mongodb
     local-port: 17017
-    db-port: 27017
+    remote-port: 27017
 
 environments:
   staging:
@@ -921,7 +921,7 @@ case "$query" in
     ".environments.staging.connections.sessions.type") echo "*mongodb" ;;
     "explode(.) | .environments.staging.connections.sessions.host") echo "mongodb.example.com" ;;
     "explode(.) | .environments.staging.connections.sessions.type.local-port") echo "17017" ;;
-    "explode(.) | .environments.staging.connections.sessions.type.db-port") echo "27017" ;;
+    "explode(.) | .environments.staging.connections.sessions.type.remote-port") echo "27017" ;;
     ".environments | keys | .[]") echo "staging" ;;
     ".environments.staging.connections | keys | .[]") echo "sessions" ;;
     *) echo "" ;;
@@ -941,7 +941,7 @@ settings:
   namespace: default
   custom-api: &custom-api
     local-port: 18080
-    db-port: 8080
+    remote-port: 8080
 
 environments:
   staging:
@@ -962,7 +962,7 @@ case "$query" in
     ".environments.staging.connections.internal-api.type") echo "*custom-api" ;;
     "explode(.) | .environments.staging.connections.internal-api.host") echo "api.example.com" ;;
     "explode(.) | .environments.staging.connections.internal-api.type.local-port") echo "18080" ;;
-    "explode(.) | .environments.staging.connections.internal-api.type.db-port") echo "8080" ;;
+    "explode(.) | .environments.staging.connections.internal-api.type.remote-port") echo "8080" ;;
     ".environments | keys | .[]") echo "staging" ;;
     ".environments.staging.connections | keys | .[]") echo "internal-api" ;;
     *) echo "" ;;
@@ -980,4 +980,241 @@ EOSCRIPT
     # User-db should have a valid host in staging
     run_plugin --env staging --connection user-db --help
     [ "$status" -eq 0 ]
+}
+
+# ==============================================================================
+# Remote Port Tests
+# ==============================================================================
+
+@test "reads remote-port from connection type for postgres" {
+    cat > "${CONFIG_FILE}" <<EOF
+settings:
+  namespace: default
+  postgres: &postgres
+    local-port: 15432
+    remote-port: 5432
+
+environments:
+  staging:
+    k8s-context: staging-context
+    connections:
+      user-db:
+        host: postgres.example.com
+        type: *postgres
+EOF
+
+    # Update mock yq
+    cat > "${TEST_DIR}/bin/yq" <<'EOSCRIPT'
+#!/usr/bin/env bash
+query="${2%% //*}"
+case "$query" in
+    ".") exit 0 ;;
+    ".environments.staging.k8s-context") echo "staging-context" ;;
+    ".environments.staging.connections.user-db.type") echo "*postgres" ;;
+    "explode(.) | .environments.staging.connections.user-db.host") echo "postgres.example.com" ;;
+    "explode(.) | .environments.staging.connections.user-db.type.local-port") echo "15432" ;;
+    "explode(.) | .environments.staging.connections.user-db.type.remote-port") echo "5432" ;;
+    ".environments | keys | .[]") echo "staging" ;;
+    ".environments.staging.connections | keys | .[]") echo "user-db" ;;
+    *) echo "" ;;
+esac
+exit 0
+EOSCRIPT
+    chmod +x "${TEST_DIR}/bin/yq"
+
+    run_plugin ls staging
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "user-db" ]]
+}
+
+@test "reads remote-port from connection type for mysql" {
+    cat > "${CONFIG_FILE}" <<EOF
+settings:
+  namespace: default
+  mysql: &mysql
+    local-port: 13306
+    remote-port: 3306
+
+environments:
+  staging:
+    k8s-context: staging-context
+    connections:
+      order-db:
+        host: mysql.example.com
+        type: *mysql
+EOF
+
+    # Update mock yq
+    cat > "${TEST_DIR}/bin/yq" <<'EOSCRIPT'
+#!/usr/bin/env bash
+query="${2%% //*}"
+case "$query" in
+    ".") exit 0 ;;
+    ".environments.staging.k8s-context") echo "staging-context" ;;
+    ".environments.staging.connections.order-db.type") echo "*mysql" ;;
+    "explode(.) | .environments.staging.connections.order-db.host") echo "mysql.example.com" ;;
+    "explode(.) | .environments.staging.connections.order-db.type.local-port") echo "13306" ;;
+    "explode(.) | .environments.staging.connections.order-db.type.remote-port") echo "3306" ;;
+    ".environments | keys | .[]") echo "staging" ;;
+    ".environments.staging.connections | keys | .[]") echo "order-db" ;;
+    *) echo "" ;;
+esac
+exit 0
+EOSCRIPT
+    chmod +x "${TEST_DIR}/bin/yq"
+
+    run_plugin ls staging
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "order-db" ]]
+}
+
+@test "reads remote-port from connection type for custom port" {
+    cat > "${CONFIG_FILE}" <<EOF
+settings:
+  namespace: default
+  custom-service: &custom-service
+    local-port: 18888
+    remote-port: 9999
+
+environments:
+  staging:
+    k8s-context: staging-context
+    connections:
+      api:
+        host: api.example.com
+        type: *custom-service
+EOF
+
+    # Update mock yq
+    cat > "${TEST_DIR}/bin/yq" <<'EOSCRIPT'
+#!/usr/bin/env bash
+query="${2%% //*}"
+case "$query" in
+    ".") exit 0 ;;
+    ".environments.staging.k8s-context") echo "staging-context" ;;
+    ".environments.staging.connections.api.type") echo "*custom-service" ;;
+    "explode(.) | .environments.staging.connections.api.host") echo "api.example.com" ;;
+    "explode(.) | .environments.staging.connections.api.type.local-port") echo "18888" ;;
+    "explode(.) | .environments.staging.connections.api.type.remote-port") echo "9999" ;;
+    ".environments | keys | .[]") echo "staging" ;;
+    ".environments.staging.connections | keys | .[]") echo "api" ;;
+    *) echo "" ;;
+esac
+exit 0
+EOSCRIPT
+    chmod +x "${TEST_DIR}/bin/yq"
+
+    run_plugin ls staging
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "api" ]]
+}
+
+@test "falls back to default remote-port when not in connection type" {
+    cat > "${CONFIG_FILE}" <<EOF
+settings:
+  namespace: default
+  remote-port: 5432
+
+environments:
+  staging:
+    k8s-context: staging-context
+    connections:
+      raw-db:
+        host: db.example.com
+EOF
+
+    # Update mock yq
+    cat > "${TEST_DIR}/bin/yq" <<'EOSCRIPT'
+#!/usr/bin/env bash
+query="${2%% //*}"
+case "$query" in
+    ".") exit 0 ;;
+    ".environments.staging.k8s-context") echo "staging-context" ;;
+    ".environments.staging.connections.raw-db.type") echo "" ;;
+    "explode(.) | .environments.staging.connections.raw-db.host") echo "db.example.com" ;;
+    "explode(.) | .environments.staging.connections.raw-db.type.local-port") echo "" ;;
+    "explode(.) | .environments.staging.connections.raw-db.type.remote-port") echo "" ;;
+    ".environments | keys | .[]") echo "staging" ;;
+    ".environments.staging.connections | keys | .[]") echo "raw-db" ;;
+    ".settings.namespace") echo "default" ;;
+    ".settings.jump-pod-image") echo "alpine/socat:latest" ;;
+    ".settings.jump-pod-wait-timeout") echo "60" ;;
+    ".settings.local-port") echo "5432" ;;
+    ".settings.remote-port") echo "5432" ;;
+    *) echo "" ;;
+esac
+exit 0
+EOSCRIPT
+    chmod +x "${TEST_DIR}/bin/yq"
+
+    run_plugin ls staging
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "raw-db" ]]
+}
+
+@test "handles different remote-port per connection type" {
+    cat > "${CONFIG_FILE}" <<EOF
+settings:
+  namespace: default
+  postgres: &postgres
+    local-port: 15432
+    remote-port: 5432
+  mysql: &mysql
+    local-port: 13306
+    remote-port: 3306
+  redis: &redis
+    local-port: 16379
+    remote-port: 6379
+
+environments:
+  staging:
+    k8s-context: staging-context
+    connections:
+      user-db:
+        host: postgres.example.com
+        type: *postgres
+      order-db:
+        host: mysql.example.com
+        type: *mysql
+      cache:
+        host: redis.example.com
+        type: *redis
+EOF
+
+    # Update mock yq
+    cat > "${TEST_DIR}/bin/yq" <<'EOSCRIPT'
+#!/usr/bin/env bash
+query="${2%% //*}"
+case "$query" in
+    ".") exit 0 ;;
+    ".environments.staging.k8s-context") echo "staging-context" ;;
+    ".environments.staging.connections.user-db.type") echo "*postgres" ;;
+    ".environments.staging.connections.order-db.type") echo "*mysql" ;;
+    ".environments.staging.connections.cache.type") echo "*redis" ;;
+    "explode(.) | .environments.staging.connections.user-db.host") echo "postgres.example.com" ;;
+    "explode(.) | .environments.staging.connections.order-db.host") echo "mysql.example.com" ;;
+    "explode(.) | .environments.staging.connections.cache.host") echo "redis.example.com" ;;
+    "explode(.) | .environments.staging.connections.user-db.type.local-port") echo "15432" ;;
+    "explode(.) | .environments.staging.connections.user-db.type.remote-port") echo "5432" ;;
+    "explode(.) | .environments.staging.connections.order-db.type.local-port") echo "13306" ;;
+    "explode(.) | .environments.staging.connections.order-db.type.remote-port") echo "3306" ;;
+    "explode(.) | .environments.staging.connections.cache.type.local-port") echo "16379" ;;
+    "explode(.) | .environments.staging.connections.cache.type.remote-port") echo "6379" ;;
+    ".environments | keys | .[]") echo "staging" ;;
+    ".environments.staging.connections | keys | .[]")
+        echo "cache"
+        echo "order-db"
+        echo "user-db"
+        ;;
+    *) echo "" ;;
+esac
+exit 0
+EOSCRIPT
+    chmod +x "${TEST_DIR}/bin/yq"
+
+    run_plugin ls staging
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "user-db" ]]
+    [[ "$output" =~ "order-db" ]]
+    [[ "$output" =~ "cache" ]]
 }


### PR DESCRIPTION
This pull request introduces a breaking change by renaming the `db-port` configuration key to `remote-port` throughout the codebase, configuration files, documentation, and tests. The update ensures consistent terminology for generic TCP connections and improves clarity for users configuring remote service ports. All references, variable names, and documentation examples have been updated accordingly.

Configuration and Documentation Updates:

* All occurrences of `db-port` in YAML configuration files (`config/config.yaml.example`, `docs/INSTALLATION.md`, `docs/USAGE.md`) are renamed to `remote-port`, including example blocks and documentation tables. [[1]](diffhunk://#diff-1281e242367d3afe688f6203748d19ec52be958dcdc4d76f84a40af5715d60adL22-R34) [[2]](diffhunk://#diff-1281e242367d3afe688f6203748d19ec52be958dcdc4d76f84a40af5715d60adL103-R103) [[3]](diffhunk://#diff-91e1e933898a9a4ff7124f5197fb4326f22effa2e9d7966bc8d75c3c15c54d18L163-R171) [[4]](diffhunk://#diff-91e1e933898a9a4ff7124f5197fb4326f22effa2e9d7966bc8d75c3c15c54d18L230-R242) [[5]](diffhunk://#diff-52296615debf3994195e43d91c94e02bfdc615a27620e0dbc72140b3de98dde1L54-R66) [[6]](diffhunk://#diff-52296615debf3994195e43d91c94e02bfdc615a27620e0dbc72140b3de98dde1L102-R102) [[7]](diffhunk://#diff-52296615debf3994195e43d91c94e02bfdc615a27620e0dbc72140b3de98dde1L142-R147) [[8]](diffhunk://#diff-52296615debf3994195e43d91c94e02bfdc615a27620e0dbc72140b3de98dde1L396-R396) [[9]](diffhunk://#diff-52296615debf3994195e43d91c94e02bfdc615a27620e0dbc72140b3de98dde1L412-R416) [[10]](diffhunk://#diff-52296615debf3994195e43d91c94e02bfdc615a27620e0dbc72140b3de98dde1L442-R442)

Script and Variable Refactoring:

* In the `kubectl-tcp_tunnel` script, all variables and function names referencing `db-port` are changed to use `remote-port`, including default values and tunnel creation logic. [[1]](diffhunk://#diff-f3eb83bb9539c0d262f4068a0833d711535012044a242b67c29d5473da636db8L21-R21) [[2]](diffhunk://#diff-f3eb83bb9539c0d262f4068a0833d711535012044a242b67c29d5473da636db8L257-R261) [[3]](diffhunk://#diff-f3eb83bb9539c0d262f4068a0833d711535012044a242b67c29d5473da636db8L515-R526) [[4]](diffhunk://#diff-f3eb83bb9539c0d262f4068a0833d711535012044a242b67c29d5473da636db8L579-R579) [[5]](diffhunk://#diff-f3eb83bb9539c0d262f4068a0833d711535012044a242b67c29d5473da636db8L608-R608) [[6]](diffhunk://#diff-f3eb83bb9539c0d262f4068a0833d711535012044a242b67c29d5473da636db8L630-R638) [[7]](diffhunk://#diff-f3eb83bb9539c0d262f4068a0833d711535012044a242b67c29d5473da636db8L373-R381)

Test Suite Alignment:

* Test files (`tests/tcp_tunnel_test.bats`) are updated to use `remote-port` instead of `db-port` in both configuration blocks and test queries, ensuring compatibility with the new terminology. [[1]](diffhunk://#diff-1858d464222de45f90533ec18f19322c7c7a01d21d0a327fc971ca4608bbd8c5L26-R30) [[2]](diffhunk://#diff-1858d464222de45f90533ec18f19322c7c7a01d21d0a327fc971ca4608bbd8c5L74-R74) [[3]](diffhunk://#diff-1858d464222de45f90533ec18f19322c7c7a01d21d0a327fc971ca4608bbd8c5L101-R107) [[4]](diffhunk://#diff-1858d464222de45f90533ec18f19322c7c7a01d21d0a327fc971ca4608bbd8c5L125-R125) [[5]](diffhunk://#diff-1858d464222de45f90533ec18f19322c7c7a01d21d0a327fc971ca4608bbd8c5L137-R137) [[6]](diffhunk://#diff-1858d464222de45f90533ec18f19322c7c7a01d21d0a327fc971ca4608bbd8c5L537-R540) [[7]](diffhunk://#diff-1858d464222de45f90533ec18f19322c7c7a01d21d0a327fc971ca4608bbd8c5L566-R568) [[8]](diffhunk://#diff-1858d464222de45f90533ec18f19322c7c7a01d21d0a327fc971ca4608bbd8c5L679-R679) [[9]](diffhunk://#diff-1858d464222de45f90533ec18f19322c7c7a01d21d0a327fc971ca4608bbd8c5L699-R699) [[10]](diffhunk://#diff-1858d464222de45f90533ec18f19322c7c7a01d21d0a327fc971ca4608bbd8c5L718-R718) [[11]](diffhunk://#diff-1858d464222de45f90533ec18f19322c7c7a01d21d0a327fc971ca4608bbd8c5L781-R788) [[12]](diffhunk://#diff-1858d464222de45f90533ec18f19322c7c7a01d21d0a327fc971ca4608bbd8c5L807-R807) [[13]](diffhunk://#diff-1858d464222de45f90533ec18f19322c7c7a01d21d0a327fc971ca4608bbd8c5L862-R862) [[14]](diffhunk://#diff-1858d464222de45f90533ec18f19322c7c7a01d21d0a327fc971ca4608bbd8c5L883-R883) [[15]](diffhunk://#diff-1858d464222de45f90533ec18f19322c7c7a01d21d0a327fc971ca4608bbd8c5L903-R903) [[16]](diffhunk://#diff-1858d464222de45f90533ec18f19322c7c7a01d21d0a327fc971ca4608bbd8c5L924-R924)

This update is important for anyone using or maintaining the tool, as it affects all configuration, usage, and testing patterns. Make sure to update your configuration files and scripts to use `remote-port` instead of `db-port`.